### PR TITLE
[BUGFIX] Doublicated DataHandler fixed (use class & namespace)

### DIFF
--- a/Classes/Hooks/SuggestReceiverCall.php
+++ b/Classes/Hooks/SuggestReceiverCall.php
@@ -16,7 +16,7 @@ namespace GeorgRinger\News\Hooks;
  */
 use GeorgRinger\News\Utility\EmConfiguration;
 use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
-use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\DataHandling\DataHandler as DataHandlerCore;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -113,8 +113,8 @@ class SuggestReceiverCall
                 ]
             ];
 
-            /** @var DataHandler $tce */
-            $tce = GeneralUtility::makeInstance(DataHandler::class);
+            /** @var DataHandlerCore $tce */
+            $tce = GeneralUtility::makeInstance(DataHandlerCore::class);
             $tce->start($tcemainData, []);
             $tce->process_datamap();
 


### PR DESCRIPTION
Fatal error: Cannot use TYPO3\CMS\Core\DataHandling\DataHandler as DataHandler because the name is already in use in ./typo3conf/ext/news/Classes/Hooks/SuggestReceiverCall.php on line 19

DataHandler already exists in same namespace (GeorgRinger\News\Hooks)
./typo3conf/ext/news/Classes/Hooks/DataHandler.php
./typo3conf/ext/news/Classes/Hooks/SuggestReceiverCall.php

SuggestReceiverCall.php
Core DataHandler include changed to "... as DataHandlerCore"