### PR TITLE
add fix for language strict mode

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -576,37 +576,43 @@ $tx_news_domain_model_news = [
                             'showitem' => '
 						--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
 						--palette--;;imageoverlayPalette,
-						--palette--;;filePalette'
+						--palette--;;filePalette,
+						sys_language_uid'
                         ],
                         \TYPO3\CMS\Core\Resource\File::FILETYPE_TEXT => [
                             'showitem' => '
 						--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
 						--palette--;;imageoverlayPalette,
-						--palette--;;filePalette'
+						--palette--;;filePalette,
+						sys_language_uid'
                         ],
                         \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
                             'showitem' => '
 						--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
 						--palette--;;imageoverlayPalette,
-						--palette--;;filePalette'
+						--palette--;;filePalette,
+						sys_language_uid'
                         ],
                         \TYPO3\CMS\Core\Resource\File::FILETYPE_AUDIO => [
                             'showitem' => '
 						--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
 						--palette--;;imageoverlayPalette,
-						--palette--;;filePalette'
+						--palette--;;filePalette,
+						sys_language_uid'
                         ],
                         \TYPO3\CMS\Core\Resource\File::FILETYPE_VIDEO => [
                             'showitem' => '
 						--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
 						--palette--;;imageoverlayPalette,
-						--palette--;;filePalette'
+						--palette--;;filePalette,
+						sys_language_uid'
                         ],
                         \TYPO3\CMS\Core\Resource\File::FILETYPE_APPLICATION => [
                             'showitem' => '
 						--palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
 						--palette--;;imageoverlayPalette,
-						--palette--;;filePalette'
+						--palette--;;filePalette,
+						sys_language_uid'
                         ]
                     ]
                 ],


### PR DESCRIPTION
Images from news objects are not displayed if language not default and language strict mode is active. The problem occurs because FAL are not saved with the correct sys_language_uid from the parent object. All FAL objects are saved with the sys_language_uid 0. To solve this Problem, there must be a possibility to set the language for the FAL object.