### PR TITLE
[BUGFIX] Use different namespace for BackendUtility in PageLayoutView

### DIFF
--- a/Classes/Hooks/PageLayoutView.php
+++ b/Classes/Hooks/PageLayoutView.php
@@ -17,7 +17,6 @@ namespace GeorgRinger\News\Hooks;
 use GeorgRinger\News\Utility\TemplateLayout;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
 use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Page\PageRenderer;
@@ -685,11 +684,11 @@ class PageLayoutView
     protected function getEditLink($row, $currentPageUid)
     {
         $editLink = '';
-        $localCalcPerms = $GLOBALS['BE_USER']->calcPerms(BackendUtility::getRecord('pages', $row['uid']));
+        $localCalcPerms = $GLOBALS['BE_USER']->calcPerms(BackendUtilityCore::getRecord('pages', $row['uid']));
         $permsEdit = $localCalcPerms & Permission::PAGE_EDIT;
         if ($permsEdit) {
-            $returnUrl = BackendUtility::getModuleUrl('web_layout', array('id' => $currentPageUid));
-            $editLink = BackendUtility::getModuleUrl('web_layout', array(
+            $returnUrl = BackendUtilityCore::getModuleUrl('web_layout', array('id' => $currentPageUid));
+            $editLink = BackendUtilityCore::getModuleUrl('web_layout', array(
                 'id' => $row['uid'],
                 'returnUrl' => $returnUrl
             ));


### PR DESCRIPTION
An old mistake has slipped in.
https://forge.typo3.org/issues/68987