### PR TITLE
[TASK] Update Index.rst to clarify usage of "previewHiddenRecords"

### DIFF
--- a/Documentation/AdministratorManual/Configuration/TypoScript/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/TypoScript/Index.rst
@@ -336,15 +336,17 @@ previewHiddenRecords
 .. container:: table-row
 
    Property
-         previewHiddenRecords
+         previewHiddenRecords / enablePreviewOfHiddenRecords 
    Data type
          int
    Description
          ::
 
             plugin.tx_news.settings.previewHiddenRecords = 1
+	    plugin.tx_news.settings.enablePreviewOfHiddenRecords = 1
 
          If set, also records which are normally hidden are displayed. This is especially helpful when using a detail view as preview mode for editors.
+	 The setting ``enablePreviewOfHiddenRecords`` is needed (instead of ``previewHiddenRecords``) if the detail view plugin is used and the plugin configuration option ``previewHiddenRecords`` is set to "Defined in TypoScript" (value ``2``).
 
          .. note:: Be aware to secure the page (e.g. using a TS condition to make it available only if an BE user is logged in) as this page could be called by anyone using any news record uid to see its content.
 


### PR DESCRIPTION
If `previewHiddenRecords` in detail view plugin FlexForm is set to `2`, the ` NewsController` will use `$this->settings['enablePreviewOfHiddenRecords']` to check if preview is enabled.

See: https://github.com/georgringer/news/blob/ab936766156377f6136cfc33849e7665ac9126c1/Classes/Controller/NewsController.php#L461

Related: #500
Related: #395