### PR TITLE
[DOCS] Fix code examples

### DIFF
--- a/Documentation/DeveloperManual/ExtendNews/Events/Index.rst
+++ b/Documentation/DeveloperManual/ExtendNews/Events/Index.rst
@@ -24,13 +24,13 @@ To connect to an event, you need to register an event listener in your custom ex
 
 .. code-block:: yaml
 
-services:
-  Vendor\Extension\EventListener\YourListener:
-    tags:
-      - name: event.listener
-        identifier: 'your-self-choosen-identifier'
-        method: 'methodToConnectToEvent'
-        event: GeorgRinger\News\Event\NewsListActionEvent
+	services:
+	  Vendor\Extension\EventListener\YourListener:
+	    tags:
+	      - name: event.listener
+		identifier: 'your-self-choosen-identifier'
+		method: 'methodToConnectToEvent'
+		event: GeorgRinger\News\Event\NewsListActionEvent
 
 Write your EventListener
 ------------------------
@@ -39,31 +39,31 @@ An example event listener can look like this:
 
 .. code-block:: php
 
-<?php
+	<?php
 
-declare(strict_types=1);
+	declare(strict_types=1);
 
-namespace Vendor\Extension\EventListener;
+	namespace Vendor\Extension\EventListener;
 
-use GeorgRinger\News\Event\NewsListActionEvent;
+	use GeorgRinger\News\Event\NewsListActionEvent;
 
-/**
- * Use NewsListActionEvent from ext:news
- */
-class YourListener
-{
-    /**
-     * Do what you want...
-     */
-    public function methodToConnectToEvent(NewsListActionEvent $event): void
-    {
-        $values = $event->getAssignedValues();
+	/**
+	 * Use NewsListActionEvent from ext:news
+	 */
+	class YourListener
+	{
+	    /**
+	     * Do what you want...
+	     */
+	    public function methodToConnectToEvent(NewsListActionEvent $event): void
+	    {
+		$values = $event->getAssignedValues();
 
-        // Do some stuff
+		// Do some stuff
 
-        $event->setAssignedValues($values);
-    }
-}
+		$event->setAssignedValues($values);
+	    }
+	}
 
 Available Events
 ----------------


### PR DESCRIPTION
This displays the code as highlighted code instead of citations