### PR TITLE
fix: prevent undefined array key warning in LinkViewHelper

### DIFF
--- a/Classes/ViewHelpers/LinkViewHelper.php
+++ b/Classes/ViewHelpers/LinkViewHelper.php
@@ -102,7 +102,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
         // Options with stdWrap enabled won't override $tsSettings as intended here: override them explicit.
         if (isset($settings['useStdWrap']) && $settings['useStdWrap']) {
             foreach (GeneralUtility::trimExplode(',', $settings['useStdWrap'], true) as $stdWrapProperty) {
-                if (is_array($tsSettings[$stdWrapProperty]) && array_key_exists($stdWrapProperty, $settings)) {
+                if (array_key_exists($stdWrapProperty, $tsSettings) && is_array($tsSettings[$stdWrapProperty]) && array_key_exists($stdWrapProperty, $settings)) {
                     $tsSettings[$stdWrapProperty] = $settings[$stdWrapProperty];
                 }
             }


### PR DESCRIPTION
The LinkViewHelper was throwing PHP warnings when trying to access array keys that don't exist in the `$tsSettings` array. Specifically, when `$stdWrapProperty` contained values like "category" that weren't present in `$tsSettings`, PHP would generate:

> PHP Warning: Undefined array key "category" in /var/www/html/vendor/georgringer/news/Classes/ViewHelpers/LinkViewHelper.php line 105
