### PR TITLE
[!!!][BUGFIX] Fix templateLayout allowedColPos issues

### DIFF
--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -47,12 +47,11 @@ class ItemsProcFunc
             $templateLayouts = $this->templateLayoutsUtility->getAvailableTemplateLayouts($pageId);
 
             $templateLayouts = $this->reduceTemplateLayouts($templateLayouts, $currentColPos);
-            foreach ($templateLayouts as $layout) {
-                $additionalLayout = [
-                    htmlspecialchars($this->getLanguageService()->sL($layout[0])),
-                    $layout[1],
+            foreach ($templateLayouts as $identifier => $label) {
+                $config['items'][] = [
+                    'label' => $this->getLanguageService()->sL($label),
+                    'value' => $identifier,
                 ];
-                array_push($config['items'], $additionalLayout);
             }
         }
     }
@@ -65,26 +64,16 @@ class ItemsProcFunc
      */
     protected function reduceTemplateLayouts($templateLayouts, $currentColPos): array
     {
+        $finalLayouts = [];
         $currentColPos = (int)$currentColPos;
-        $restrictions = [];
-        $allLayouts = [];
-        foreach ($templateLayouts as $key => $layout) {
-            if (is_array($layout[0])) {
-                if (isset($layout[0]['allowedColPos']) && str_ends_with((string)$layout[1], '.')) {
-                    $layoutKey = substr($layout[1], 0, -1);
-                    $restrictions[$layoutKey] = GeneralUtility::intExplode(',', $layout[0]['allowedColPos'], true);
-                }
-            } else {
-                $allLayouts[$key] = $layout;
+        foreach ($templateLayouts as $key => $configuration) {
+            if (isset($configuration['allowedColPos']) && !GeneralUtility::inList($configuration['allowedColPos'], (string)$currentColPos)) {
+                continue;
             }
-        }
-        foreach ($restrictions as $restrictedIdentifier => $restrictedColPosList) {
-            if (!in_array($currentColPos, $restrictedColPosList, true)) {
-                unset($allLayouts[$restrictedIdentifier]);
-            }
+            $finalLayouts[$key] = $configuration['label'];
         }
 
-        return $allLayouts;
+        return $finalLayouts;
     }
 
     /**

--- a/Classes/Hooks/PluginPreviewRenderer.php
+++ b/Classes/Hooks/PluginPreviewRenderer.php
@@ -444,8 +444,8 @@ class PluginPreviewRenderer extends StandardContentPreviewRenderer
         if (!empty($field)) {
             $layouts = $this->templateLayoutsUtility->getAvailableTemplateLayouts($pageUid);
             foreach ($layouts as $layout) {
-                if ((string)$layout[1] === $field) {
-                    $title = $layout[0];
+                if ((string)$layout['key'] === $field) {
+                    $title = $layout['label'] ?? '';
                 }
             }
         }

--- a/Documentation/Tutorials/ExtendNews/ExtendFlexforms/Index.rst
+++ b/Documentation/Tutorials/ExtendNews/ExtendFlexforms/Index.rst
@@ -22,18 +22,6 @@ The sorting can be extended by adding the value to
 
 Default values are: tstamp,datetime,crdate,title
 
-Additional Template Selector
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you need a kind of template selector inside a plugin, you can add
-your own selections by adding those to
-
-.. code-block:: php
-
-   $GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts']['myext'] = ['My Title', 'my value'];
-
-You can then access the variable in your template with
-:code:`{settings.templateLayout}` and use it for a condition or whatever.
-
 Extend FlexForms with custom fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 If you need additional fields in the FlexForm configuration, this can be done by using a hook in the Core.

--- a/Tests/Unit/Hooks/PluginPreviewRendererTest.php
+++ b/Tests/Unit/Hooks/PluginPreviewRendererTest.php
@@ -174,7 +174,7 @@ class PluginPreviewRendererTest extends BaseTestCase
         $flexform = [];
         $mockedTemplateLayout = $this->getAccessibleMock(TemplateLayout::class, ['getAvailableTemplateLayouts']);
 
-        $mockedTemplateLayout->expects(self::once())->method('getAvailableTemplateLayouts')->willReturn([['bar', 'fo']]);
+        $mockedTemplateLayout->expects(self::once())->method('getAvailableTemplateLayouts')->willReturn(['fo' => ['key' => 'fo', 'label' => 'bar']]);
 
         $this->addContentToFlexform($flexform, 'settings.templateLayout', 'fo', 'template');
         $this->pageLayoutView->_set('flexformData', $flexform);

--- a/Tests/Unit/Utility/TemplateLayoutTest.php
+++ b/Tests/Unit/Utility/TemplateLayoutTest.php
@@ -19,26 +19,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 class TemplateLayoutTest extends BaseTestCase
 {
     #[Test]
-    public function templatesFoundInTypo3ConfVars(): void
-    {
-        $GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts'] = [
-            0 => [
-                0 => 'Layout 1',
-                1 => 'layout1',
-            ],
-            1 => [
-                0 => 'Layout 2',
-                1 => 'layout2',
-            ],
-        ];
-
-        $templateLayoutUtility = $this->getAccessibleMock(TemplateLayout::class, ['getTemplateLayoutsFromTsConfig']);
-        $templateLayoutUtility->expects(self::once())->method('getTemplateLayoutsFromTsConfig')->willReturn([]);
-        $templateLayouts = $templateLayoutUtility->_call('getAvailableTemplateLayouts', 1);
-        self::assertSame($GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts'], $templateLayouts);
-    }
-
-    #[Test]
     public function templatesFoundInPageTsConfig(): void
     {
         $tsConfigArray = [
@@ -46,50 +26,13 @@ class TemplateLayoutTest extends BaseTestCase
             'layout2' => 'Layout 2',
         ];
         $result = [
-            0 => [
-                0 => 'Layout 1',
-                1 => 'layout1',
+            'layout1' => [
+                'label' => 'Layout 1',
+                'key' => 'layout1',
             ],
-            1 => [
-                0 => 'Layout 2',
-                1 => 'layout2',
-            ],
-        ];
-
-        // clear TYPO3_CONF_VARS
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts']);
-
-        $templateLayoutUtility = $this->getAccessibleMock(TemplateLayout::class, ['getTemplateLayoutsFromTsConfig']);
-        $templateLayoutUtility->expects(self::once())->method('getTemplateLayoutsFromTsConfig')->willReturn($tsConfigArray);
-        $templateLayouts = $templateLayoutUtility->_call('getAvailableTemplateLayouts', 1);
-        self::assertSame($result, $templateLayouts);
-    }
-
-    #[Test]
-    public function templatesFoundInCombinedResources(): void
-    {
-        $tsConfigArray = [
-            'layout1' => 'Layout 1',
-            'layout2' => 'Layout 2',
-        ];
-        $GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts'] = [
-            0 => [
-                0 => 'Layout 4',
-                1 => 'layout4',
-            ],
-        ];
-        $result = [
-            0 => [
-                0 => 'Layout 4',
-                1 => 'layout4',
-            ],
-            1 => [
-                0 => 'Layout 1',
-                1 => 'layout1',
-            ],
-            2 => [
-                0 => 'Layout 2',
-                1 => 'layout2',
+            'layout2' => [
+                'label' => 'Layout 2',
+                'key' => 'layout2',
             ],
         ];
 


### PR DESCRIPTION
To simplify the configuration, the possibility to configure templateLayouts via `$GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts]` has been dropped in favor of TsConfig only.

Additionally a bug regarding restrictions with allowedColPos has been fixed.

Resolves: #1988