### PR TITLE
[!!!][TASK] Remove usage of LOAD_REGISTER with news values

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -29,7 +29,6 @@ use GeorgRinger\News\Pagination\QueryResultPaginator;
 use GeorgRinger\News\Seo\NewsTitleProvider;
 use GeorgRinger\News\Utility\Cache;
 use GeorgRinger\News\Utility\ClassCacheManager;
-use GeorgRinger\News\Utility\Page;
 use GeorgRinger\News\Utility\TypoScript;
 use GeorgRinger\NumberedPagination\NumberedPagination;
 use Psr\Http\Message\ResponseInterface;
@@ -393,7 +392,6 @@ class NewsController extends NewsBaseController
         }
 
         if ($news !== null) {
-            Page::setRegisterProperties($this->settings['detail']['registerProperties'] ?? false, $news);
             Cache::addCacheTagsByNewsRecords([$news]);
             Cache::addCacheTagsByNewsRecords($news->getRelated()->toArray());
 

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -101,7 +101,6 @@ plugin.tx_news {
 		detail {
 			errorHandling = showStandaloneTemplate,EXT:news/Resources/Private/Templates/News/DetailNotFound.html,404
 			checkPidOfNewsRecord = 0
-			registerProperties = keywords,title
 			showPrevNext = 0
 			showSocialShareButtons = 1
 			showMetaTags = 1

--- a/Documentation/Reference/TypoScript/GeneralSettings.rst
+++ b/Documentation/Reference/TypoScript/GeneralSettings.rst
@@ -493,19 +493,6 @@ detail.showPrevNext
 
    If enabled, links to the previous and next news records are shown
 
-.. _tsDetailRegisterProperties:
-
-detail.registerProperties
-=========================
-
-.. confval:: detail.registerProperties
-
-   :type: string
-   :Path: plugin.tx_news.settings
-   :Default: keywords,title
-
-   This property is currently not used.
-
 .. _tsDetailShowSocialShareButtons:
 
 detail.showSocialShareButtons

--- a/Tests/Functional/Fixtures/TypoScript/setup.typoscript
+++ b/Tests/Functional/Fixtures/TypoScript/setup.typoscript
@@ -81,7 +81,6 @@ plugin.tx_news {
     detail {
       errorHandling = showStandaloneTemplate,EXT:news/Resources/Private/Templates/News/DetailNotFound.html,404
       checkPidOfNewsRecord = 0
-      registerProperties = keywords,title
       showPrevNext = 0
       showSocialShareButtons = 1
       showMetaTags = 1


### PR DESCRIPTION
The method `\GeorgRinger\News\Utility\Page::setRegisterProperties` and the related setting `detail.registerProperties` have been removed. Those have been used to fill the ContentObjectRenderer's register with values of the news object.

This is not used since several versions and the controller should not mess up that register.

Resolves: #2514