### PR TITLE
[BUGFIX]  Set allowed access option in the backend module registration

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -16,7 +16,7 @@ if ($configuration->getShowAdministrationModule() && !ExtensionManagementUtility
         'web_newsAdministration' => [
             'parent' => 'web',
             'position' => ['after' => '*'],
-            'access' => 'user,group',
+            'access' => 'admin',
             'path' => '/module/web/NewsAdministration/',
             'iconIdentifier' => 'ext-news-module-administration',
             'labels' => 'LLL:EXT:news/Resources/Private/Language/locallang_modadministration.xlf',


### PR DESCRIPTION
This patch removes the outdated value (module was not available to select in the module permissions options of TYPO3) and changes it to admin for now as the functionality of the module needs the installation of a separate package
(georgringer/news-administration).

Fixes: #2711