### PR TITLE
[BUGFIX] Prevent duplicate IDs from localized content elements

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -860,7 +860,7 @@ class News extends AbstractEntity
         $contentElements = $this->getContentElements();
         if ($contentElements) {
             foreach ($contentElements as $contentElement) {
-                if ($contentElement->getColPos() >= 0) {
+                if ($contentElement->getColPos() >= 0 && $contentElement->getSysLanguageUid() === $this->getSysLanguageUid()) {
                     $idList[] = $original ? $contentElement->getUid() : $contentElement->_getProperty('_localizedUid');
                 }
             }
@@ -880,7 +880,7 @@ class News extends AbstractEntity
         $contentElements = $this->getContentElements();
         if ($contentElements) {
             foreach ($contentElements as $contentElement) {
-                if ($contentElement->getColPos() >= 0 && $contentElement->getTxContainerParent() === 0) {
+                if ($contentElement->getColPos() >= 0 && $contentElement->getTxContainerParent() === 0 && $contentElement->getSysLanguageUid() === $this->getSysLanguageUid()) {
                     $idList[] = $original ? $contentElement->getUid() : $contentElement->_getProperty('_localizedUid');
                 }
             }

--- a/Classes/Domain/Model/TtContent.php
+++ b/Classes/Domain/Model/TtContent.php
@@ -134,6 +134,14 @@ class TtContent extends AbstractEntity
         $this->tstamp = $tstamp;
     }
 
+    /**
+     * Get sys language
+     */
+    public function getSysLanguageUid(): int
+    {
+        return $this->_languageUid;
+    }
+
     public function getCType(): string
     {
         return $this->CType;


### PR DESCRIPTION
When rendering a news detail view, the collected content element ID list could contain duplicates if both the default record and its localized variant were attached. Both reported the same UID via `getUid()`, resulting in identical IDs in `{newsItem.contentElementIdList}`.

This patch adds a language check in `getIdOfContentElements()` and `getIdOfNonNestedContentElements()` to ensure only content elements matching the current language of the news record are considered.

As a result, the ID list is now language-aware and free of duplicates.

Resolves: #2714