### PR TITLE
[TASK] Align the Symfony dependencies with the TYPO3 Core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">= 8.1 < 8.5",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
+        "symfony/console": "^6.4 || ^7.0",
         "typo3/cms-backend": "^12.4.37 || ^13.4.15",
         "typo3/cms-core": "^12.4.37 || ^13.4.15",
         "typo3/cms-extbase": "^12.4.37 || ^13.4.15",


### PR DESCRIPTION
The lowest TYPO3 version this package supports is 12LTS, and the lowest Symfony Console version TYPO3 12LTS supports is 6.4.

So we can safely drop support for Symfony Console 5.x.