### PR TITLE
[BUGFIX] Match composer description with v14 title handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "georgringer/news",
-    "description": "Versatile news system based on Extbase & Fluid and using the latest technologies provided by TYPO3 CMS.",
+    "description": "News system - Versatile news system based on Extbase & Fluid and using the latest technologies provided by TYPO3 CMS.",
     "license": "GPL-2.0-or-later",
     "type": "typo3-cms-extension",
     "keywords": [


### PR DESCRIPTION
Since TYPO3 v14, the extension title is populated from composer.json. This patch adds the missing "title" field and updates the description to match ext_emconf.php. This ensures consistent metadata and prevents ComposerDeficitDetector `EXTENSION_TITLE_MISSING` warning.

References: [Breaking: #108304 - Populate extension title from composer.json](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108304-PopulateExtensionTitleFromComposerJson.html)