### PR TITLE
[fix] Tag based viewhelpers can receive arbitrary attributes, additio…

### DIFF
--- a/Resources/Private/Partials/Detail/MediaImage.html
+++ b/Resources/Private/Partials/Detail/MediaImage.html
@@ -6,18 +6,18 @@
 	<f:if condition="{mediaElement.link}">
 		<f:then>
 			<f:link.typolink parameter="{mediaElement.link}" target="{n:targetLink(link:mediaElement.link)}">
-				<f:image image="{mediaElement}" title="{mediaElement.title}" alt="{mediaElement.alternative}" loading="{settings.detail.media.image.lazyLoading}" maxWidth="{f:if(condition: settings.media.maxWidth, then: settings.media.maxWidth, else: settings.detail.media.image.maxWidth)}" maxHeight="{f:if(condition: settings.media.maxHeight, then: settings.media.maxHeight, else: settings.detail.media.image.maxHeight)}" additionalAttributes="{itemprop:'image'}" />
+				<f:image image="{mediaElement}" title="{mediaElement.title}" alt="{mediaElement.alternative}" loading="{settings.detail.media.image.lazyLoading}" maxWidth="{f:if(condition: settings.media.maxWidth, then: settings.media.maxWidth, else: settings.detail.media.image.maxWidth)}" maxHeight="{f:if(condition: settings.media.maxHeight, then: settings.media.maxHeight, else: settings.detail.media.image.maxHeight)}" itemprop="image" />
 			</f:link.typolink>
 		</f:then>
 		<f:else>
 			<f:if condition="{settings.detail.media.image.lightbox.enabled}">
 				<f:then>
 					<a href="{f:uri.image(image:mediaElement, width:'{settings.detail.media.image.lightbox.width}', height:'{settings.detail.media.image.lightbox.height}')}" title="{mediaElement.title}" class="{settings.detail.media.image.lightbox.class}" rel="{settings.detail.media.image.lightbox.rel}">
-						<f:image image="{mediaElement}" title="{mediaElement.title}" alt="{mediaElement.alternative}" loading="{settings.detail.media.image.lazyLoading}" maxWidth="{f:if(condition: settings.media.maxWidth, then: settings.media.maxWidth, else: settings.detail.media.image.maxWidth)}" maxHeight="{f:if(condition: settings.media.maxHeight, then: settings.media.maxHeight, else: settings.detail.media.image.maxHeight)}" additionalAttributes="{itemprop:'image'}" />
+						<f:image image="{mediaElement}" title="{mediaElement.title}" alt="{mediaElement.alternative}" loading="{settings.detail.media.image.lazyLoading}" maxWidth="{f:if(condition: settings.media.maxWidth, then: settings.media.maxWidth, else: settings.detail.media.image.maxWidth)}" maxHeight="{f:if(condition: settings.media.maxHeight, then: settings.media.maxHeight, else: settings.detail.media.image.maxHeight)}" itemprop="image" />
 					</a>
 				</f:then>
 				<f:else>
-					<f:image image="{mediaElement}" title="{mediaElement.title}" alt="{mediaElement.alternative}" loading="{settings.detail.media.image.lazyLoading}" maxWidth="{f:if(condition: settings.media.maxWidth, then: settings.media.maxWidth, else: settings.detail.media.image.maxWidth)}" maxHeight="{f:if(condition: settings.media.maxHeight, then: settings.media.maxHeight, else: settings.detail.media.image.maxHeight)}" additionalAttributes="{itemprop:'image'}" />
+					<f:image image="{mediaElement}" title="{mediaElement.title}" alt="{mediaElement.alternative}" loading="{settings.detail.media.image.lazyLoading}" maxWidth="{f:if(condition: settings.media.maxWidth, then: settings.media.maxWidth, else: settings.detail.media.image.maxWidth)}" maxHeight="{f:if(condition: settings.media.maxHeight, then: settings.media.maxHeight, else: settings.detail.media.image.maxHeight)}" itemprop="image" />
 				</f:else>
 			</f:if>
 		</f:else>

--- a/Resources/Private/Partials/List/Item.html
+++ b/Resources/Private/Partials/List/Item.html
@@ -10,7 +10,7 @@
 	<!-- header -->
 	<div class="header">
 		<h3>
-			<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}" additionalAttributes="{itemprop:'url'}">
+			<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}" itemprop="url">
 				<span itemprop="headline">{newsItem.title}</span>
 			</n:link>
 		</h3>

--- a/Resources/Private/Templates/Styles/Twb/Partials/List/Item.html
+++ b/Resources/Private/Templates/Styles/Twb/Partials/List/Item.html
@@ -24,7 +24,7 @@
 
 	<div class="col-md-9 articletype-{newsItem.type}{f:if(condition: newsItem.istopnews, then: ' topnews')}" itemscope="itemscope" itemtype="http://schema.org/Article">
 		<h3 itemprop="headline">
-			<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}" additionalAttributes="{itemprop:'url'}">
+			<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}" itemprop="url">
 				{newsItem.title}
 			</n:link>
 		</h3>

--- a/Resources/Private/Templates/Styles/Twb5/Partials/List/Item.html
+++ b/Resources/Private/Templates/Styles/Twb5/Partials/List/Item.html
@@ -25,7 +25,7 @@
 
 	<div class="col-md-9 articletype-{newsItem.type}{f:if(condition: newsItem.istopnews, then: ' topnews')}" itemscope="itemscope" itemtype="http://schema.org/Article">
 		<h3 itemprop="headline">
-			<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}" additionalAttributes="{itemprop:'url'}">
+			<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}" itemprop="url">
 				{newsItem.title}
 			</n:link>
 		</h3>


### PR DESCRIPTION
Though the additionalAttributes argument is still available, tag based viewhelpers can receive arbitrary attributes, additional fix for #2752

See
https://github.com/TYPO3/Fluid/pull/859
https://get.typo3.org/release-notes/12.4.18
https://github.com/TYPO3/typo3/commit/f4f0ddb44d6