### PR TITLE
[BUGFIX] Add support for news preview in AddNewsToMenuProcessor

### DIFF
--- a/Classes/DataProcessing/AddNewsToMenuProcessor.php
+++ b/Classes/DataProcessing/AddNewsToMenuProcessor.php
@@ -83,7 +83,11 @@ class AddNewsToMenuProcessor implements DataProcessorInterface
     {
         /** @var PageArguments $routing */
         $routing = $GLOBALS['TYPO3_REQUEST']->getAttribute('routing');
-        $newsId = (int)($routing->getArguments()['tx_news_pi1']['news'] ?? 0);
+        $newsId = (int)(
+            $routing->getArguments()['tx_news_pi1']['news']
+            ?? $routing->getArguments()['tx_news_pi1']['news_preview']
+            ?? 0
+        );
 
         if ($newsId) {
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)


### PR DESCRIPTION
The data processor `AddNewsToMenuProcessor` doesn't handle news preview.

This PR fixes that by checking the `news_preview` request parameter.