### PR TITLE
[BUGFIX] Make `mailto:` link work in news administration module

### DIFF
--- a/Configuration/ContentSecurityPolicies.php
+++ b/Configuration/ContentSecurityPolicies.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Directive;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Mutation;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\MutationCollection;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\MutationMode;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\RawValue;
+use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Scope;
+use TYPO3\CMS\Core\Type\Map;
+
+return Map::fromEntries([
+    Scope::backend(),
+    new MutationCollection(
+        new Mutation(
+            MutationMode::Extend,
+            Directive::FrameSrc,
+            // Required for news administration module
+            new RawValue('mailto:'),
+        ),
+    ),
+]);


### PR DESCRIPTION
The `mailto:` link in the news administration module does not work by default, because of a missing CSP `frame-src` directive. This is now fixed by this PR: A CSP configuration is provided to extend the `frame-src` directive with a `mailto:` source.