### PR TITLE
[BUGFIX] Ensure news datetime defaults are converted in FormEngine

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,6 +11,7 @@ use GeorgRinger\News\Routing\NewsTitleMapper;
 use GeorgRinger\News\Utility\ClassCacheManager;
 use GeorgRinger\News\Utility\ClassLoader;
 use GeorgRinger\News\Xclass\ExtensionServiceXclassed;
+use TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowDateTimeFields;
 use TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew;
 use TYPO3\CMS\Core\Cache\Backend\FileBackend;
 use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
@@ -157,6 +158,9 @@ $boot = static function (): void {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][NewsRowInitializeNew::class] = [
         'depends' => [
             DatabaseRowInitializeNew::class,
+        ],
+        'before' => [
+            DatabaseRowDateTimeFields::class,
         ],
     ];
 


### PR DESCRIPTION
Register NewsRowInitializeNew before DatabaseRowDateTimeFields in the tcaDatabaseRecord form data group, so timestamp defaults set by news are converted by core datetime processing before rendering in TYPO3 v14.

Keeps TYPO3 v13 behavior unchanged and restores TYPO3 v14 compatibility.

Resolves: #2779