### PR TITLE
[BUGFIX] 503 error - news detail - type declaration is missing

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -81,11 +81,11 @@ class News extends AbstractEntity
 
     /** @var ObjectStorage<News> */
     #[Lazy]
-    protected $related;
+    protected ObjectStorage $related;
 
     /** @var ObjectStorage<News> */
     #[Lazy]
-    protected $relatedFrom;
+    protected ObjectStorage $relatedFrom;
 
     /**
      * Fal related files
@@ -117,7 +117,7 @@ class News extends AbstractEntity
      * @var ObjectStorage<FileReference>
      */
     #[Lazy]
-    protected $falMedia;
+    protected ObjectStorage $falMedia;
 
     /**
      * Fal media items with showinpreview set


### PR DESCRIPTION
Avoid 503 error when a news article is called due to missing type declarations [ObjectStorage] in news model - TYPO3 13.4.28 - PHP 8.3.6