### PR TITLE
[BUGFIX] Missing initialization of $related and $relatedFrom properties

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -181,6 +181,8 @@ class News extends AbstractEntity
         $this->falMedia = new ObjectStorage();
         $this->falRelatedFiles = new ObjectStorage();
         $this->tags = new ObjectStorage();
+        $this->related = new ObjectStorage();
+        $this->relatedFrom = new ObjectStorage();
     }
 
     /**
@@ -194,6 +196,8 @@ class News extends AbstractEntity
         $this->falMedia ??= new ObjectStorage();
         $this->falRelatedFiles ??= new ObjectStorage();
         $this->tags ??= new ObjectStorage();
+        $this->related ??= new ObjectStorage();
+        $this->relatedFrom ??= new ObjectStorage();
     }
 
     public function getTitle(): string


### PR DESCRIPTION
Since v14.0.3 the `related` and `relatedFrom` properties in the News model are no longer properly initialized, which causes errors when extensions that extend the News model try to access these properties.

fixes #2805