### PR TITLE
[TASK] Allow path_segment in workspaces

### DIFF
--- a/Configuration/TCA/Overrides/sys_category.php
+++ b/Configuration/TCA/Overrides/sys_category.php
@@ -136,7 +136,6 @@ $newSysCategoryColumns = [
     'slug' => [
         'exclude' => true,
         'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:pages.slug',
-        'displayCond' => 'VERSION:IS:false',
         'config' => [
             'type' => 'slug',
             'size' => 50,

--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -458,7 +458,6 @@ $tx_news_domain_model_news = [
         ],
         'path_segment' => [
             'label' => $ll . 'tx_news_domain_model_news.path_segment',
-            'displayCond' => 'VERSION:IS:false',
             'config' => [
                 'type' => 'slug',
                 'size' => 50,

--- a/Configuration/TCA/tx_news_domain_model_tag.php
+++ b/Configuration/TCA/tx_news_domain_model_tag.php
@@ -110,7 +110,6 @@ return [
         'slug' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:pages.slug',
-            'displayCond' => 'VERSION:IS:false',
             'config' => [
                 'type' => 'slug',
                 'size' => 50,


### PR DESCRIPTION
This reverts 16372344ecbef80cb363267d9cc41db040b23616 because nowadays the field `path_segment` is type=slug that's fully compatible with workspaces. The before mentioned workaround was necessary due to this extensions custom way of creating slugs before TYPO3 offered that clean way of defining fields as slug fields.

Resolves: #2813