### PR TITLE
[BUGFIX] Render plugin preview check icons via IconFactory

### DIFF
--- a/Classes/Hooks/PluginPreviewRenderer.php
+++ b/Classes/Hooks/PluginPreviewRenderer.php
@@ -366,7 +366,7 @@ class PluginPreviewRenderer implements PreviewRendererInterface
             if ($includeSubcategories) {
                 $this->tableData[] = [
                     $this->getLanguageService()->sL(self::LLPATH . 'flexforms_general.includeSubCategories'),
-                    '<i class="fa fa-check"></i>',
+                    $this->iconFactory->getIcon('actions-check', IconSize::SMALL)->render(),
                 ];
             }
         }
@@ -411,7 +411,7 @@ class PluginPreviewRenderer implements PreviewRendererInterface
         if ($hidePagination) {
             $this->tableData[] = [
                 $this->getLanguageService()->sL(self::LLPATH . 'flexforms_additional.hidePagination'),
-                '<i class="fa fa-check"></i>',
+                $this->iconFactory->getIcon('actions-check', IconSize::SMALL)->render(),
             ];
         }
     }
@@ -489,7 +489,7 @@ class PluginPreviewRenderer implements PreviewRendererInterface
                 $this->getLanguageService()->sL(
                     self::LLPATH . 'flexforms_additional.disableOverrideDemand'
                 ),
-                '<i class="fa fa-check"></i>',
+                $this->iconFactory->getIcon('actions-check', IconSize::SMALL)->render(),
             ];
         }
     }


### PR DESCRIPTION
- Font Awesome was removed from the TYPO3 backend, so the hardcoded <i class="fa fa-check"> markup in the plugin preview renderer no longer produces any glyph. The boolean flexform settings (hidePagination, includeSubCategories, disableOverrideDemand) therefore showed an empty cell in the Web > Page module preview on TYPO3 v13/v14
- Render the checkmark through the injected IconFactory using the core "actions-check" identifier instead, so the icon displays again across all supported versions.