### PR TITLE
[TASK] Do not load every parent category to build the category tree

### DIFF
--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -211,6 +211,22 @@ class Category extends AbstractEntity
             : $this->parentcategory;
     }
 
+    /**
+     * Uid of the parent category, without loading the parent category itself.
+     *
+     * Use this instead of getParentcategory()->getUid() if only the uid is needed,
+     * as the parent category is a lazy relation and would have to be fetched first.
+     */
+    public function getParentcategoryUid(): ?int
+    {
+        $parentcategory = $this->parentcategory;
+        if ($parentcategory instanceof LazyLoadingProxy) {
+            return $parentcategory->getUid() ?: null;
+        }
+
+        return $parentcategory?->getUid() ?: null;
+    }
+
     public function setParentcategory(Category $category): void
     {
         $this->parentcategory = $category;

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -104,7 +104,7 @@ class CategoryRepository extends AbstractDemandedRepository
         foreach ($categories as $category) {
             $flatCategories[$category->getUid()] = [
                 'item' => $category,
-                'parent' => ($category->getParentcategory()) ? $category->getParentcategory()->getUid() : null,
+                'parent' => $category->getParentcategoryUid(),
             ];
         }
 
@@ -112,7 +112,7 @@ class CategoryRepository extends AbstractDemandedRepository
 
         // If leaves are selected without its parents selected, those are shown as parent
         foreach ($flatCategories as $id => &$flatCategory) {
-            if (!isset($flatCategories[$flatCategory['parent']])) {
+            if ($flatCategory['parent'] === null || !isset($flatCategories[$flatCategory['parent']])) {
                 $flatCategory['parent'] = null;
             }
         }

--- a/Tests/Functional/Fixtures/sys_category_nested.csv
+++ b/Tests/Functional/Fixtures/sys_category_nested.csv
@@ -1,0 +1,7 @@
+sys_category,,,,
+,uid,pid,parent,title
+,1,1,0,"Root A"
+,2,1,1,"A-1"
+,3,1,2,"A-1-1"
+,4,1,2,"A-1-2"
+,5,1,1,"A-2"

--- a/Tests/Functional/Repository/CategoryRepositoryTest.php
+++ b/Tests/Functional/Repository/CategoryRepositoryTest.php
@@ -54,4 +54,29 @@ class CategoryRepositoryTest extends FunctionalTestCase
 
         self::assertEquals('findRecordByImportSource', $category->getTitle());
     }
+
+    #[Test]
+    public function findTreeReturnsNestedCategories(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/sys_category_nested.csv');
+
+        $tree = $this->categoryRepository->findTree([1]);
+
+        self::assertSame([1], array_keys($tree));
+        self::assertSame([2, 5], array_keys($tree[1]['children']));
+        self::assertSame([3, 4], array_keys($tree[1]['children'][2]['children']));
+        self::assertArrayNotHasKey('children', $tree[1]['children'][5]);
+    }
+
+    #[Test]
+    public function findTreeShowsCategoriesWithoutSelectedParentAsRoot(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/sys_category_nested.csv');
+
+        // 2 is a child of 1, but 1 is not part of the tree
+        $tree = $this->categoryRepository->findTree([2]);
+
+        self::assertSame([2], array_keys($tree));
+        self::assertSame([3, 4], array_keys($tree[2]['children']));
+    }
 }

--- a/Tests/Unit/Domain/Model/CategoryTest.php
+++ b/Tests/Unit/Domain/Model/CategoryTest.php
@@ -13,6 +13,8 @@ use DateTime;
 use GeorgRinger\News\Domain\Model\Category;
 use GeorgRinger\News\Domain\Model\FileReference;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
+use TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
@@ -323,6 +325,60 @@ class CategoryTest extends BaseTestCase
         self::assertSame(
             $value,
             $this->instance->getParentcategory()
+        );
+    }
+
+    #[Test]
+    public function getParentcategoryUidInitiallyReturnsNull(): void
+    {
+        self::assertNull(
+            $this->instance->getParentcategoryUid()
+        );
+    }
+
+    #[Test]
+    public function getParentcategoryUidReturnsUidOfParentcategory(): void
+    {
+        $value = new Category();
+        $value->_setProperty('uid', 123);
+        $this->instance->setParentcategory($value);
+        self::assertSame(
+            123,
+            $this->instance->getParentcategoryUid()
+        );
+    }
+
+    #[Test]
+    public function getParentcategoryUidDoesNotResolveTheLazyLoadingProxy(): void
+    {
+        $dataMapper = $this->getMockBuilder(DataMapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dataMapper->expects(self::never())->method('fetchRelated');
+        $this->instance->_setProperty(
+            'parentcategory',
+            new LazyLoadingProxy($this->instance, 'parentcategory', 123, $dataMapper)
+        );
+
+        self::assertSame(
+            123,
+            $this->instance->getParentcategoryUid()
+        );
+    }
+
+    #[Test]
+    public function getParentcategoryUidReturnsNullForAnEmptyLazyLoadingProxy(): void
+    {
+        $dataMapper = $this->getMockBuilder(DataMapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->instance->_setProperty(
+            'parentcategory',
+            new LazyLoadingProxy($this->instance, 'parentcategory', 0, $dataMapper)
+        );
+
+        self::assertNull(
+            $this->instance->getParentcategoryUid()
         );
     }
 


### PR DESCRIPTION
## Problem

`CategoryRepository::findTree()` resolves the parent of every category through the getter:

```php
foreach ($categories as $category) {
    $flatCategories[$category->getUid()] = [
        'item' => $category,
        'parent' => ($category->getParentcategory()) ? $category->getParentcategory()->getUid() : null,
    ];
}
```

`parentcategory` is a `#[Lazy]` relation, so `getParentcategory()` calls `_loadRealInstance()`, which runs a query plus the language overlay for **every single category in the tree** — only to read the uid from the loaded object. The parent objects themselves are never used here.

I found this while profiling a news page on an installation with a few thousand categories: rendering the category menu spent a noticeable part of its time in `Typo3DbBackend::getObjectDataByQuery()` and `PageRepository::getRecordOverlay()`, all triggered from this loop.

## Change

`Category::getParentcategoryUid()` reads the uid from the lazy loading proxy without resolving it, and `findTree()` uses that instead. The new method is also useful on its own — reading the uid of a lazy relation without fetching it is a common need.

```php
public function getParentcategoryUid(): ?int
{
    $parentcategory = $this->parentcategory;
    if ($parentcategory instanceof LazyLoadingProxy) {
        return $parentcategory->getUid() ?: null;
    }

    return $parentcategory?->getUid() ?: null;
}
```

## Result

On a news page with 374 categories in the tree, **326 of them were behind an unresolved lazy loading proxy**, so this saves 326 queries (plus their language overlays) per `findTree()` call.

## Correctness

The uid on the proxy is the raw `parent` value of the row Extbase loaded, while the old code read the uid of the mapped parent object. I checked that these agree on an installation with 3152 categories, of which 3010 are translations, comparing both values for every category in three site languages: **374 categories checked, 0 differences.**

## Tests

* Unit tests for `getParentcategoryUid()`, including one asserting that `DataMapper::fetchRelated()` is **never** called, which is the actual point of the change.
* Functional tests for `findTree()` covering nested categories and the "leaf selected without its parent" case. `findTree()` had no test coverage so far.

## Note on the null guard

The added `findTree()` tests fail on `main` under PHP 8.5 with *"Using null as an array offset is deprecated"* (the suites run with `failOnDeprecation="true"`), because a root category has no parent. This PR therefore contains the same one line guard as #2788. If #2788 is merged first, this part becomes a no-op and I am happy to rebase.