### PR TITLE
[BUGFIX] Make typo3/seo-sitemap an optional set dependency

### DIFF
--- a/Configuration/Sets/Sitemap/config.yaml
+++ b/Configuration/Sets/Sitemap/config.yaml
@@ -2,4 +2,5 @@ name: georgringer/news-sitemap
 label: 'EXT:news :: Sitemap'
 dependencies:
   - georgringer/news
+optionalDependencies:
   - typo3/seo-sitemap


### PR DESCRIPTION
## Problem

The `georgringer/news-sitemap` site set declares `typo3/seo-sitemap` as a **hard** dependency, while `typo3/cms-seo` is only a `suggest` / `require-dev` dependency of the extension.

TYPO3 validates every registered set on boot, so whenever `cms-seo` is not installed the system log is permanently flooded with:

```
[ERROR] Invalid set "georgringer/news-sitemap": Missing dependency "typo3/seo-sitemap"
```

…even when the sitemap functionality is not used at all.

## Fix

Move `typo3/seo-sitemap` from `dependencies` to `optionalDependencies`:

- **cms-seo present** → the set still orders after `typo3/seo-sitemap` (via the "after-resilient" ordering) and works as before.
- **cms-seo absent** → the set stays valid and inert; no error is logged.

This avoids forcing `typo3/cms-seo` into `require`. `optionalDependencies` for site sets is available since TYPO3 v13.3, so it works on both the 13.4 and 14 branches supported by the extension.

Resolves #2808

🤖 Generated with [Claude Code](https://claude.com/claude-code)