### PR TITLE
[TASK] Update actions/checkout to v5

### DIFF
--- a/.github/workflows/core13.yml
+++ b/.github/workflows/core13.yml
@@ -15,7 +15,7 @@ jobs:
         composerInstall: [ 'composerInstallLowest', 'composerInstallHighest' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install testing system
         run: Build/Scripts/runTests.sh -t 13 -p ${{ matrix.php }}  -s ${{ matrix.composerInstall }}

--- a/.github/workflows/core14.yml
+++ b/.github/workflows/core14.yml
@@ -15,7 +15,7 @@ jobs:
         composerInstall: [ 'composerInstallLowest', 'composerInstallHighest' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install testing system
         run: Build/Scripts/runTests.sh -t 14 -p ${{ matrix.php }}  -s ${{ matrix.composerInstall }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Test if the documentation will render without warnings
         run: |


### PR DESCRIPTION
`actions/checkout@v3` (core13/core14) and `@v4` (documentation) run on a Node.js version that GitHub Actions now reports as deprecated, producing a warning in every workflow run.

Bump all three workflows to `actions/checkout@v5`, which runs on Node 24.

Resolves #2830

🤖 Generated with [Claude Code](https://claude.com/claude-code)