### PR TITLE
[BUGFIX] Reset categories for selectedListAction

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -250,6 +250,7 @@ class NewsController extends NewsBaseController
     {
         $newsRecords = [];
 
+        $this->settings['categories'] = '';
         $demand = $this->createDemandObjectFromSettings($this->settings);
         $demand->setActionAndClass(__METHOD__, self::class);
 


### PR DESCRIPTION
As selected list doesn't have any categories, the setting is unset.

Resolves: #2810