### PR TITLE
[DOCS] Update RSS/iCalendar TypoScript condition for TYPO3 13+

### DIFF
--- a/Documentation/Tutorials/BestPractice/ICalendar/Index.rst
+++ b/Documentation/Tutorials/BestPractice/ICalendar/Index.rst
@@ -27,7 +27,7 @@ A very simple way to generate the iCalendar feed is using plain TypoScript. All 
 
 .. code-block:: typoscript
 
-    [getTSFE() && getTSFE().type == 9819]
+    [request && request.getPageArguments()?.getPageType() == 9819]
     config {
        disableAllHeaderCode = 1
        xhtml_cleaning = none
@@ -119,7 +119,7 @@ The TypoScript code looks like this.
 
 .. code-block:: typoscript
 
-    [getTSFE() && getTSFE().type == 9819]
+    [request && request.getPageArguments()?.getPageType() == 9819]
        lib.stdheader >
        tt_content.stdWrap.innerWrap >
        tt_content.stdWrap.wrap >

--- a/Documentation/Tutorials/BestPractice/Rss/Index.rst
+++ b/Documentation/Tutorials/BestPractice/Rss/Index.rst
@@ -121,7 +121,7 @@ The TypoScript code looks like this.
 
 .. code-block:: typoscript
 
-   [getTSFE() && getTSFE().type == {$plugin.tx_news.rss.channel.typeNum}]
+   [request && request.getPageArguments()?.getPageType() == {$plugin.tx_news.rss.channel.typeNum}]
       lib.stdheader >
       tt_content.stdWrap.innerWrap >
       tt_content.stdWrap.wrap >


### PR DESCRIPTION
The RSS and iCalendar best-practice chapters set up the feed page type with the TypoScript condition:

```typoscript
[getTSFE() && getTSFE().type == ...]
```

`TSFE`'s `type` property was [deprecated in TYPO3 12.4](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-100405-PropertyTypoScriptFrontendController-type.html) and no longer works on v13+, so the condition never matched and the feeds broke.

Replaced with the request-based page type in all three occurrences (RSS ×1, iCalendar ×2):

```typoscript
[request && request.getPageArguments()?.getPageType() == ...]
```

Thanks to @guelzow for reporting and providing the working replacement.

Resolves #2770

🤖 Generated with [Claude Code](https://claude.com/claude-code)